### PR TITLE
Fix Android CI (armv7 cross-compile + emulator stability)

### DIFF
--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -22,27 +22,20 @@ jobs:
   android-armv7:
     name: Android (armv7 cross-compile)
     runs-on: ubuntu-latest
-    container: swift:6.3.3
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Install dependencies
-      run: apt-get update -y && apt-get install -y curl
-    - name: Install Swift Android SDK
-      # The Android SDK artifact bundle is only published for 6.3.3, and the
-      # host toolchain must match the bundle version exactly (Swift's module
-      # format isn't cross-patch-compatible) — hence the swift:6.3.3 container.
-      run: |
-        set -eux
-        url="https://download.swift.org/swift-6.3.3-release/android-sdk/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE_android.artifactbundle.tar.gz"
-        curl -fsSL "$url" -o android.artifactbundle.tar.gz
-        swift sdk install android.artifactbundle.tar.gz \
-          --checksum d160cc3206dd1886dae3fef2337af5e25ec034692cd0ec225721c56cc69da7f5
-        swift sdk list
     # armv7 can't run on the x86_64 emulator, so this is a cross-compile check
-    # only. The bundle installs as a single multi-arch SDK; the architecture is
-    # selected by target triple. The SDK's armv7 triples are named
-    # `armv7-unknown-linux-android<api>` (not `...androideabi<api>`), one per
-    # Android API level 28-36.
-    - name: Build (armv7)
-      run: swift build --swift-sdk armv7-unknown-linux-android28
+    # only (build-tests/run-tests off skips the emulator entirely). The action
+    # provisions the Android NDK and points the SDK at it via ANDROID_NDK_HOME;
+    # a bare `swift:6.3.3` container can't build for Android because the SDK's
+    # `ndk-sysroot` (semaphore.h, libc, …) is supplied by the NDK, not the
+    # bundle. The action's build command already targets x86_64, so append a
+    # second `--swift-sdk` for armv7 (last one wins) to retarget the compile.
+    - name: Cross-compile for armv7
+      uses: skiptools/swift-android-action@v2
+      with:
+        swift-version: 6.3.3
+        build-tests: false
+        run-tests: false
+        swift-build-flags: --swift-sdk armv7-unknown-linux-android28

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -15,9 +15,15 @@ jobs:
       uses: skiptools/swift-android-action@v2
       with:
         swift-version: 6.3.3
-        # Free disk space before launching the emulator; without the headroom
-        # the emulator has been getting OOM-killed (adb exit 137) right after boot.
+        # Free disk space before launching the emulator for extra headroom.
         free-disk-space: true
+        # The GitHub-hosted x86_64 emulator intermittently dies with exit 137
+        # right after "Emulator booted" (adb: device offline). Force a cold boot
+        # (-no-snapshot, avoiding a crash-prone snapshot restore) with software
+        # rendering (-gpu swiftshader_indirect) and a generous boot timeout to
+        # make the boot deterministic.
+        android-emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+        android-emulator-boot-timeout: 900
 
   android-armv7:
     name: Android (armv7 cross-compile)

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -15,6 +15,9 @@ jobs:
       uses: skiptools/swift-android-action@v2
       with:
         swift-version: 6.3.3
+        # Free disk space before launching the emulator; without the headroom
+        # the emulator has been getting OOM-killed (adb exit 137) right after boot.
+        free-disk-space: true
 
   android-armv7:
     name: Android (armv7 cross-compile)
@@ -38,12 +41,8 @@ jobs:
         swift sdk list
     # armv7 can't run on the x86_64 emulator, so this is a cross-compile check
     # only. The bundle installs as a single multi-arch SDK; the architecture is
-    # selected by target triple. Read the exact armv7 triple (with its
-    # API-level suffix) from the installed SDK metadata rather than pinning it.
+    # selected by target triple. The SDK's armv7 triples are named
+    # `armv7-unknown-linux-android<api>` (not `...androideabi<api>`), one per
+    # Android API level 28-36.
     - name: Build (armv7)
-      run: |
-        set -eux
-        TRIPLE=$(grep -rhoE 'armv7-unknown-linux-androideabi[0-9]*' ~/.swiftpm | sort -u | head -1)
-        test -n "$TRIPLE"
-        echo "Using target triple: $TRIPLE"
-        swift build --swift-sdk "$TRIPLE"
+      run: swift build --swift-sdk armv7-unknown-linux-android28


### PR DESCRIPTION
Follow-up to #8, which was merged before the Android jobs were fully green.
These three commits fix the two Android CI jobs. Net change is limited to
`.github/workflows/swift-android.yml`.

## Changes
- **armv7 cross-compile** — the swift.org Android SDK bundle ships no
  `ndk-sysroot` (its libc/headers come from the Android NDK). A bare
  `swift:6.3.3` container therefore can't cross-compile (`'semaphore.h' file not
  found`). The armv7 build now runs through `skiptools/swift-android-action`,
  which provisions the NDK and wires `ANDROID_NDK_HOME`, retargeting the compile
  to `armv7-unknown-linux-android28` via `swift-build-flags`. Tests are disabled
  for this job so no emulator is launched.
- **Emulator stability** — the hosted x86_64 emulator was intermittently dying
  with exit 137 (SIGKILL) right after boot, failing the unit-test job
  non-deterministically. Force a cold boot (`-no-snapshot`) with software
  rendering (`-gpu swiftshader_indirect`) and a longer boot timeout, plus
  `free-disk-space: true` for headroom.

## Verification
- `Android (armv7 cross-compile)` — passing.
- `Android (unit tests)` — the emulator-hardening change is validated by this
  PR's own CI run.